### PR TITLE
Добавить план первой фазы реализации jgit / Add jgit Phase 1 implementation plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/netkeep80/BinDiffSynchronizer/issues/5
-Your prepared branch: issue-5-ce618776ec3e
-Your prepared working directory: /tmp/gh-issue-solver-1772047152467
-Your forked repository: konard/netkeep80-BinDiffSynchronizer
-Original repository (upstream): netkeep80/BinDiffSynchronizer
-
-Proceed.


### PR DESCRIPTION
## Summary

Resolves #5 — разработка плана первой фазы реализации jgit в отдельном файле.

- Created `phase1-plan.md` — a detailed Phase 1 implementation plan for the jgit temporal JSON database
- The plan is derived from analysis of `analysis.md`, `plan.md`, and `readme.md`

## What's in `phase1-plan.md`

The document covers 5 concrete steps for Phase 1 (1–3 months):

1. **Fix existing bugs** — `>` vs `>>` in `PageDevice.h`, `NULL` vs `0` in `persist.h`, missing `return *this` in `fptr::operator=`
2. **Migrate to C++17 + CMake** — replace MSVC-specific code (`__forceinline`, `typeof`, `_ultoa`, `<strstream>`), add `std::filesystem`, create cross-platform `CMakeLists.txt`
3. **Integrate nlohmann/json** — add as header-only dependency, select CBOR as binary format, write `jgit/serialization.h`
4. **Content-addressed object store** — SHA-256 hashing, Git-like `.jgit/objects/` layout on disk, `ObjectStore` class with `put(json)` → hash and `get(hash)` → json
5. **Unit tests + CI** — Catch2 tests for all new and fixed code, GitHub Actions CI for Linux/Windows

## File Structure After Phase 1

```
jgit/hash.h              — SHA-256 content addressing
jgit/serialization.h     — JSON ↔ CBOR conversion
jgit/object_store.h      — content-addressed object store
tests/                   — unit tests (Catch2)
CMakeLists.txt           — cross-platform build
.github/workflows/ci.yml — CI pipeline
third_party/             — nlohmann/json, sha256
```

## Acceptance Criteria

Phase 1 is complete when:
- All known bugs are fixed and covered by regression tests
- Project compiles on Linux with GCC and Clang via CMake
- All unit tests pass
- CI runs on every push
- `ObjectStore::put` / `ObjectStore::get` work end-to-end
- No MSVC-specific code remains in headers

## Test plan

- [ ] Review `phase1-plan.md` for completeness and accuracy
- [ ] Verify all references to `analysis.md`, `plan.md`, `readme.md` are correct
- [ ] Confirm the 5-step scope aligns with the short-term plan in `plan.md`
- [ ] Check that all acceptance criteria are measurable and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)