### PR TITLE
Доработка ТЗ на jhub: ответы на открытые вопросы (#38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/netkeep80/BinDiffSynchronizer/issues/38
-Your prepared branch: issue-38-bff51514899b
-Your prepared working directory: /tmp/gh-issue-solver-1772102804296
-Your forked repository: konard/netkeep80-BinDiffSynchronizer
-Original repository (upstream): netkeep80/BinDiffSynchronizer
-
-Proceed.


### PR DESCRIPTION
## Описание

Доработка технического задания jhub-tz.md (v1.0 → v1.1) в соответствии с ответами на открытые вопросы из issue #38.

Closes #38

## Внесённые изменения

### Раздел 7: «Нерешённые вопросы» → «Принятые решения»

Все открытые вопросы закрыты конкретными решениями:

| Вопрос | Принятое решение |
|--------|-----------------|
| Язык API Server | **Go** (основной) или **Rust** (для performance-critical компонентов); требуется дальнейший анализ → [migration-analysis.md](https://github.com/netkeep80/jsonRVM/blob/master/migration-analysis.md) |
| jsonRVM зрелость | **Требует доработки**: исправить C++ краткосрочно, перейти на Go среднесрочно |
| Совместимость с Git | **Нет** — jgit не совместим с форматом Git-репозитория |
| Хранение бинарных файлов | **Тип `binary` в persistent_json** + ссылки `$ref`/`$bin`; base64 при экспорте |
| Индексирование jdb | **Да** — B-tree индексы по JSON-полям в Фазе 5.4 |
| Сетевой протокол jgit | **HTTP/2 + REST** (совместимость с браузерами и Web GUI) |

### Раздел 2.2: NFR-4 (Совместимость)

Уточнено: jgit не совместим с форматом Git-репозитория; импорт стандартных Git-репо не предусмотрен.

### Раздел 3.2: API Server (Компонент 3)

Уточнён технологический стек: Go/Rust вместо C++, HTTP/2 + REST вместо HTTP/1.1.

### Раздел 3.2: jgit сетевой протокол (Компонент 1)

Добавлен явный подраздел о выборе HTTP/2 + REST для push/pull операций.

### Новый раздел 5.3: Хранение бинарных файлов в jdb

Детальное описание механизма хранения бинарных данных через тип `binary`/`$bin` с примером JSON.

### Раздел 4.2: Фаза 5.4

Уточнена задача: добавлены B-tree индексы по JSON-полям для оптимизации queries.

### Раздел 6.1: Фаза 6.1.1

Уточнён стек: Go или Rust HTTP/2-сервер (вместо C++ или Go).

## Связанные материалы

- Issue: netkeep80/BinDiffSynchronizer#38
- Анализ миграции jsonRVM: [migration-analysis.md](https://github.com/netkeep80/jsonRVM/blob/master/migration-analysis.md)
- Предыдущая версия ТЗ: PR #37

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)