### PR TITLE
perf: fix O(n²) slot_map operations — 681x speedup on Ubuntu/GCC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/netkeep80/BinDiffSynchronizer/issues/100
-Your prepared branch: issue-100-de4991e76843
-Your prepared working directory: /tmp/gh-issue-solver-1772356135175
-Your forked repository: konard/netkeep80-BinDiffSynchronizer
-Original repository (upstream): netkeep80/BinDiffSynchronizer
-
-Proceed.


### PR DESCRIPTION
## Summary

Fixes #100: Tests were ~6x slower on Ubuntu/GCC due to two compounding O(n²) bottlenecks in `PersistentAddressSpace` (`pam_core.h`).

### Root cause 1: O(n) shift of `name_idx` on every name insert/delete

`SlotInfo.name_idx` stored the **positional index** of the slot's name in `name_map`. Every time a name was inserted or deleted, `_shift_name_indices_after_insert()` / `_shift_name_indices_after_delete()` scanned **all n slot entries** to update their `name_idx` fields. With 100k+ allocations:
```
n inserts × O(n) scan = O(n²)
```

**Fix:** Changed `name_idx` from a positional index to a **boolean flag** (0 = named, `PAM_INVALID_IDX` = unnamed). Removed the O(n) shift functions entirely. `GetName()` and `Delete()` now do a O(n_names) linear scan over the much-smaller `name_map` (typically far fewer entries than slot_map).

### Root cause 2: O(n) slot_map lookup × O(n) deletions

`_slot_lower_bound()` used **linear scan** through all slot entries. Each `pam.Delete()` did:
- O(n) linear scan to find the slot
- O(n) left-shift of all remaining entries

For 221k nodes: `221k deletions × O(221k) = O(n²)`.

**Fix:** 
- `_slot_insert()`: changed from sorted-insert-with-shift to **O(1) append** to end (unsorted)
- `Delete()`: changed slot removal from **O(n) left-shift to O(1) swap-with-last**
- `_slot_lower_bound()`: now delegates to `_slot_index_cache` — an `std::unordered_map<offset, index>` member — for **O(1) average lookup**, maintained in sync with every slot_map change (insert, delete, load, reset)

## Benchmark results (Ubuntu/GCC)

| Test | Before (reported) | After |
|------|-------------------|-------|
| Total 349 tests | **2725 seconds** | **4 seconds** (681x) |
| PAM stress: 1M pstrings | 335.9s | 3.8s (88x) |
| pjson large: from_string | 338.8s | 0.19s (1780x) |
| pjson large: full round-trip | 342.6s | 0.40s (855x) |
| pjson serial: round-trip test.json | 338.4s | 0.41s (824x) |

## Changes

- `pam_core.h`:
  - Removed `_shift_name_indices_after_insert()` and `_shift_name_indices_after_delete()`
  - Changed `name_idx` semantics: 0 = named (flag), `PAM_INVALID_IDX` = unnamed
  - Changed `_slot_insert()` to O(1) append (unsorted)
  - Changed slot deletion from O(n) left-shift to O(1) swap-with-last
  - Added `_slot_index_cache` (`std::unordered_map`) for O(1) slot lookup
  - Updated `_slot_lower_bound()` to use the cache
  - Updated `GetName()`, `Delete()`, `Validate()`, `_alloc()` rollback accordingly

## Test plan

- [x] All 349 tests pass locally
- [x] Fast tests (308): 0.74s total
- [x] Slow tests (41): 5.67s total (was measured at 2000+ seconds)
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)